### PR TITLE
Notifications on errors when modifying

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,6 +39,7 @@
     "activeTab",
     "storage",
     "tabs",
-    "contextMenus"
+    "contextMenus",
+    "notifications"
   ]
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "LaSuli",
   "description": "Social annotation for qualitative analysis.",
-  "version": "3.0.2",
+  "version": "3.0.3",
 
   "manifest_version": 2,
   "applications": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "LaSuli",
   "description": "Social annotation for qualitative analysis.",
-  "version": "3.0.1",
+  "version": "3.0.2",
 
   "manifest_version": 2,
   "applications": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LaSuli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Web extension to annotate text.",
   "scripts": {
     "start": "webpack && web-ext run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LaSuli",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Web extension to annotate text.",
   "scripts": {
     "start": "webpack && web-ext run",

--- a/src/backgroundScripts/background.js
+++ b/src/backgroundScripts/background.js
@@ -95,6 +95,8 @@ browser.runtime.onMessage.addListener(async (msg) => {
       return model.createHighlight(msg.uri,msg.viewpoint,msg.topic,msg.coordinates);
     case 'removeHighlight':
       return model.removeHighlight(msg.uri,msg.viewpoint,msg.topic,msg.fragId);
+    case 'renameTopic':
+      return model.renameTopic(msg.viewpoint,msg.topic,msg.newName);
     case 'setHLNumber':
       if (msg.count && msg.tabId) {
         return setHLNumber(msg.count,msg.tabId);

--- a/src/backgroundScripts/background.js
+++ b/src/backgroundScripts/background.js
@@ -7,8 +7,12 @@ import model from './model.js';
  */
 
 const errorHandler = (error, tabId) => {
-	console.error(error);
-	button.setBadgeText({text: 'err', tabId});
+  console.error(error);
+  browser.notifications.create({
+    type:"basic",
+    title:"LaSuli error",
+    message:String(error)
+  });
 };
 
 let button = browser.browserAction,
@@ -25,26 +29,26 @@ browser.windows.getCurrent({populate: true}).then((window) => {
 button.setBadgeBackgroundColor({color: '#333'});
 
 const setHLNumber = (number,tabId) => {
-	var text;
-	if (typeof number !== "number") text=null;
-	else if (number < 0) text='…';
-	else text=String(number);
-	button.setBadgeText({text,tabId});
+  var text;
+  if (typeof number !== "number") text=null;
+  else if (number < 0) text='…';
+  else text=String(number);
+  return button.setBadgeText({text,tabId});
 }
 
 const updateHighlightNumber = async (tabId, url, refresh) => {
-	// The page must be whitelisted
-	let isOk = await model.isWhitelisted(url);
-	if (!isOk) {
-		button.setIcon({tabId});
-		setHLNumber(false,tabId);
-		return;
-	} else {
-		button.setIcon({
-			path: {32: '/button/laSuli-32.png'},
-			tabId
-		});
-	}
+  // The page must be whitelisted
+  let isOk = await model.isWhitelisted(url);
+  if (!isOk) {
+    return button.setIcon({tabId}).then(x => {
+      return setHLNumber(false,tabId);
+    });
+  } else {
+    return button.setIcon({
+      path: {32: '/button/laSuli-32.png'},
+      tabId
+    });
+  }
 
 	// Get the number of highlights for this URL
 	setHLNumber(-1,tabId);
@@ -86,26 +90,41 @@ button.onClicked.addListener(() => browser.sidebarAction.open());
  * Message handler
  */
 browser.runtime.onMessage.addListener(async (msg) => {
+  let res;
   switch (msg.aim) {
     case 'getResource':
-      return model.getResource(msg.uri, msg.reload);
+      res=model.getResource(msg.uri, msg.reload);
+      break;
     case 'isWhitelisted':
-      return model.isWhitelisted(msg.uri);
+      res=model.isWhitelisted(msg.uri);
+      break;
     case 'createHighlight':
-      return model.createHighlight(msg.uri,msg.viewpoint,msg.topic,msg.coordinates);
+      res=model.createHighlight(msg.uri,msg.viewpoint,msg.topic,msg.coordinates);
+      break;
     case 'removeHighlight':
-      return model.removeHighlight(msg.uri,msg.viewpoint,msg.topic,msg.fragId);
+      res=model.removeHighlight(msg.uri,msg.viewpoint,msg.topic,msg.fragId);
+      break;
     case 'renameTopic':
-      return model.renameTopic(msg.viewpoint,msg.topic,msg.newName);
+      res=model.renameTopic(msg.viewpoint,msg.topic,msg.newName);
+      break;
     case 'setHLNumber':
       if (msg.count && msg.tabId) {
-        return setHLNumber(msg.count,msg.tabId);
+        res=setHLNumber(msg.count,msg.tabId);
+      } else {
+        res=Promise.reject("missing count or tabId");
       }
+      break;
     case 'fetchSession':
-      return model.fetchSession();
+      res=model.fetchSession();
+      break;
     case 'openSession':
-      return model.openSession(msg.user, msg.password);
+      res=model.openSession(msg.user, msg.password);
+      break;
     case 'closeSession':
-      return model.closeSession();
+      res=model.closeSession();
+      break;
+    default:
+      res=Promise.reject("unknown message "+$msg.aim);
   }
+  return res.catch(errorHandler);
 });

--- a/src/backgroundScripts/background.js
+++ b/src/backgroundScripts/background.js
@@ -13,6 +13,7 @@ const errorHandler = (error, tabId) => {
     title:"LaSuli error",
     message:String(error)
   });
+  return Promise.reject();
 };
 
 let button = browser.browserAction,

--- a/src/backgroundScripts/background.js
+++ b/src/backgroundScripts/background.js
@@ -109,11 +109,7 @@ browser.runtime.onMessage.addListener(async (msg) => {
       res=model.renameTopic(msg.viewpoint,msg.topic,msg.newName);
       break;
     case 'setHLNumber':
-      if (msg.count && msg.tabId) {
-        res=setHLNumber(msg.count,msg.tabId);
-      } else {
-        res=Promise.reject("missing count or tabId");
-      }
+      res=setHLNumber(msg.count,msg.tabId);
       break;
     case 'fetchSession':
       res=model.fetchSession();

--- a/src/backgroundScripts/model.js
+++ b/src/backgroundScripts/model.js
@@ -110,18 +110,6 @@ const model = (function () {
 		return [];
 	};
 
-	const getCorpusVps = async (item) => {
-		let view = await db.getView(`/corpus/${item.corpus}`);
-		let topics = Object.keys(view[item.corpus])
-			.filter(key => !(key in ['name', 'user']))
-			.map(key => view[item.corpus][key])
-			.map(res => Object.keys(res).map(k => res[k].topic));
-
-		topics = [].concat(... [].concat(... topics).filter(Boolean));
-		return Array.from(
-			new Set(topics.map(t => t.viewpoint).filter(Boolean)));
-	};
-
 	const getHighlights = async (uri) => {
 		let itemLists = (await getItems(uri)) || {};
 		let items = [].concat(... Object.values(itemLists));
@@ -129,10 +117,8 @@ const model = (function () {
 		// For each item, run getItemHighlights and getCorpusVps
 		// Wait for all highlights and flatten the resulting array
 		let hls = Promise.all(items.map(getItemHighlights));
-		let vps = Promise.all(items.map(getCorpusVps));
 		return {
 			highlights: [].concat(... await hls),
-			viewpoints: Array.from(new Set([].concat(... await vps)))
 		};
 	};
 

--- a/src/backgroundScripts/model.js
+++ b/src/backgroundScripts/model.js
@@ -42,29 +42,34 @@ const model = (function () {
 		}).join("");
 	}
 
-	const createHighlight = async (uri,viewpoint,topic,coordinates) => {
-		if (!topic) topic=getUuid();
-		if (!viewpoint) viewpoint=getUuid();
-		let items=await getItems(uri);
-		if (items && items.item && items.item.length>0) {
-			let itemId=items.item[0].id;
-			let item=await db.get({_id:itemId})
-				.catch(x=>console.error(x));
-			var uuid=getUuid();
-			item.highlights=item.highlights || {};
-			let hl={
-				coordinates:[coordinates.startPos,coordinates.endPos],
-				text:coordinates.text,
-				viewpoint:viewpoint,
-				topic:topic
-			};
-			item.highlights[uuid]=hl;
-			let res=await db.post(item);
-			hl.id=uuid;
-			return hl;
-		}
-		return false;
-	}
+  const createHighlight = async (uri,viewpoint,topic,coordinates) => {
+    if (!topic) topic=getUuid();
+    if (!viewpoint) viewpoint=getUuid();
+    let items=await getItems(uri);
+    if (items && items.item && items.item.length>0) {
+      let itemId=items.item[0].id;
+      let item=await db.get({_id:itemId})
+        .catch(e => {
+           return {
+             _id: itemId,
+             item_corpus: items.item[0].corpus
+           };
+         });
+      var uuid=getUuid();
+      item.highlights=item.highlights || {};
+      let hl={
+        coordinates:[coordinates.startPos,coordinates.endPos],
+        text:coordinates.text,
+        viewpoint:viewpoint,
+        topic:topic
+      };
+      item.highlights[uuid]=hl;
+      let res=await db.post(item);
+      hl.id=uuid;
+      return hl;
+    }
+    return false;
+  }
 
 	const removeHighlight = async (uri,viewpoint,topic,fragId) => {
 		let items=await getItems(uri);

--- a/src/backgroundScripts/model.js
+++ b/src/backgroundScripts/model.js
@@ -81,6 +81,28 @@ const model = (function () {
 		return false
 	}
 
+  const renameTopic = (vpId,topicId,newName) => {
+    return db.get({_id:vpId})
+    .catch(x => {
+      return {_id:vpId,topics:{},viewpoint_name:"",users:[]};
+    })
+    .then(vp => {
+      if (vp.topics.constructor === Array) vp.topics={};
+      vp.viewpoint_name=vp.viewpoint_name || "Sans nom";
+      vp.users=vp.users || [];
+      let topic=vp.topics[topicId] || {};
+      if (!topic.name || topic.name != newName) {
+        topic.name=newName;
+        vp.topics[topicId]=topic;
+        return db.post(vp).then( x => {
+          return topic;
+        });
+      } else {
+        return topic;
+      }
+    });
+  }
+
 	/*
 	 * Fetch the item(s) for the given resource (URI)
 	 */
@@ -263,7 +285,8 @@ const model = (function () {
     isWhitelisted,
     getResource,
     createHighlight,
-    removeHighlight
+    removeHighlight,
+    renameTopic
   };
 }());
 

--- a/src/backgroundScripts/model.js
+++ b/src/backgroundScripts/model.js
@@ -41,45 +41,52 @@ const model = (function () {
 		}).join("");
 	}
 
-	const createHighlight = async (uri,viewpoint,topic,coordinates) => {
-		if (!topic) topic=getUuid();
-		if (!viewpoint) viewpoint=getUuid();
-		let items=await getItems(uri);
-		if (items && items.item && items.item.length>0) {
-			let itemId=items.item[0].id;
-			let item=await db.get({_id:itemId})
-				.catch(x=>console.error(x));
-			var uuid=getUuid();
-			item.highlights=item.highlights || {};
-			let hl={
-				coordinates:[coordinates.startPos,coordinates.endPos],
-				text:coordinates.text,
-				viewpoint:viewpoint,
-				topic:topic
-			};
-			item.highlights[uuid]=hl;
-			let res=await db.post(item);
-			hl.id=uuid;
-			return hl;
-		}
-		return false;
-	}
+  const createHighlight = (uri,viewpoint,topic,coordinates) => {
+    if (!topic) topic=getUuid();
+    if (!viewpoint) viewpoint=getUuid();
+    return getItems(uri)
+      .then(items => {
+        if (items && items.item && items.item.length>0) {
+          let itemId=items.item[0].id;
+          return db.get({_id:itemId});
+        }
+        throw new Error ("no items found for "+uri);
+      })
+      .then(item => {
+        var uuid=getUuid();
+        item.highlights=item.highlights || {};
+        let hl={
+          coordinates:[coordinates.startPos,coordinates.endPos],
+          text:coordinates.text,
+          viewpoint:viewpoint,
+          topic:topic
+        };
+        item.highlights[uuid]=hl;
+        return db.post(item).then(createdItem => {
+          hl.id=uuid;
+          return hl;
+        });
+      });
+  }
 
-	const removeHighlight = async (uri,viewpoint,topic,fragId) => {
-		let items=await getItems(uri);
-		if (items && items.item && items.item.length>0) {
-			let itemId=items.item[0].id;
-			let item=await db.get({_id:itemId})
-				.catch(x=>console.error(x));
-			if (fragId in item.highlights) {
-				delete item.highlights[fragId];
-				let res=await db.post(item);
-				return res;
-			}
-			return new Promise().resolve();
-		}
-		return false
-	}
+  const removeHighlight = (uri,viewpoint,topic,fragId) => {
+    return getItems(uri)
+      .then(items => {
+        if (items && items.item && items.item.length>0) {
+          let itemId=items.item[0].id;
+          return db.get({_id:itemId});
+        } else {
+          throw new Error(`can't find item for ${uri}`);
+        }
+      })
+      .then(item => {
+        if (fragId in item.highlights) {
+          delete item.highlights[fragId];
+          return db.post(item);
+        } else {
+        }
+      });
+  }
 
   const renameTopic = (vpId,topicId,newName) => {
     return db.get({_id:vpId})

--- a/src/sidebar/jsx/Display.jsx
+++ b/src/sidebar/jsx/Display.jsx
@@ -4,14 +4,15 @@ import Viewpoint from './Viewpoint.jsx';
 import Topic from './Topic.jsx';
 
 export default class Display extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {vp: null};
-		browser.contextMenus.removeAll();
-		this._deleteFrag=this._deleteFrag.bind(this);
-		this._createFrag=this._createFrag.bind(this);
-		this._contextMenuListener=this._contextMenuListener.bind(this);
-	}
+  constructor(props) {
+    super(props);
+    this.state = {vp: null};
+    browser.contextMenus.removeAll();
+    this._deleteFrag=this._deleteFrag.bind(this);
+    this._createFrag=this._createFrag.bind(this);
+    this._renameTopic=this._renameTopic.bind(this);
+    this._contextMenuListener=this._contextMenuListener.bind(this);
+  }
 
 	_contextMenuListener(info,tab) {
 		if (info.menuItemId=="highlightnew" && this.state.vpId) {
@@ -85,6 +86,18 @@ export default class Display extends React.Component {
 		}
 	}
 
+  _renameTopic(topic,newName) {
+    let viewpoint=this.state.vpId;
+    return browser.runtime.sendMessage({
+      aim:'renameTopic',viewpoint,topic,newName
+    }).then(x => {
+      this.setState(previousState => {
+        previousState.vp.topics[topic].name=newName;
+        return previousState;
+      });
+    });
+  }
+
 	async _highlight(labels, fragments) {
 		return this._loadScript().then(_ => browser.tabs.sendMessage(this.props.tabId, {
 			aim: 'highlight',
@@ -148,13 +161,14 @@ export default class Display extends React.Component {
 		});
 	}
 
-	_getTopics(labels) {
-		return Object.keys(this.state.vp.topics).map((id,i) =>
-			<Topic details={this.state.vp.topics[id]} id={id} index={i} vpId={this.state.vpId}
-				color={labels[id].color} name={this.state.vp.topics[id].name}
-				createFrag={this._createFrag} deleteFrag={this._deleteFrag} />
-		);
-	}
+  _getTopics(labels) {
+    return Object.keys(this.state.vp.topics).map((id,i) =>
+      <Topic details={this.state.vp.topics[id]} id={id} index={i} vpId={this.state.vpId}
+        color={labels[id].color} name={this.state.vp.topics[id].name}
+        createFrag={this._createFrag} deleteFrag={this._deleteFrag}
+        renameTopic={this._renameTopic} />
+    );
+  }
 
 	_getButton() {
 		let back = () => {

--- a/src/sidebar/jsx/Display.jsx
+++ b/src/sidebar/jsx/Display.jsx
@@ -49,42 +49,43 @@ export default class Display extends React.Component {
 		</div>);
 	}
 
-	async _createFrag(tab,topic) {
-		function addHL(vp,hl) {
-			hl.text=[].concat(hl.text);
-			hl.coordinates=[hl.coordinates];
-			vp.topics[hl.topic] = vp.topics[hl.topic] || [];
-			vp.topics[hl.topic].push(hl);
-			return vp;
-		}
-		if (this.state.vpId) {
-			return this.props.createFrag(tab,this.state.vpId,topic).then( hl => {
-				if (hl.topic) {
-					this.setState(previousState => {
-						addHL(previousState.vp,hl);
-						return previousState;
-					});
-				}
-				return hl;
-			});
-		}
-	}
+  _createFrag(tab,topic) {
+    function addHL(vp,hl) {
+      hl.text=[].concat(hl.text);
+      hl.coordinates=[hl.coordinates];
+      vp.topics[hl.topic] = vp.topics[hl.topic] || [];
+      vp.topics[hl.topic].push(hl);
+      return vp;
+    }
+    if (this.state.vpId) {
+      return this.props.createFrag(tab,this.state.vpId,topic)
+        .then( hl => {
+          if (hl.topic) {
+            this.setState(previousState => {
+              addHL(previousState.vp,hl);
+              return previousState;
+            });
+          }
+          return hl;
+        });
+    }
+  }
 
-	async _deleteFrag(topic,fragId) {
-		function removeHL(vp) {
-			vp.topics[topic]=vp.topics[topic].filter(hl => {return hl.id!=fragId});
-			return vp;
-		}
-		if (this.state.vp && this.state.vpId) {
-			return this.props.deleteFrag(this.state.vpId,topic,fragId).then( x => {
-				this.setState(previousState => {
-					removeHL(previousState.vp);
-					return previousState;
-				});
-				return x;
-			});
-		}
-	}
+  _deleteFrag(topic,fragId) {
+    function removeHL(vp) {
+      vp.topics[topic]=vp.topics[topic].filter(hl => {return hl.id!=fragId});
+      return vp;
+    }
+    if (this.state.vp && this.state.vpId) {
+      return this.props.deleteFrag(this.state.vpId,topic,fragId).then( x => {
+        this.setState(previousState => {
+          removeHL(previousState.vp);
+          return previousState;
+        });
+        return x;
+      });
+    }
+  }
 
   _renameTopic(topic,newName) {
     let viewpoint=this.state.vpId;

--- a/src/sidebar/jsx/Topic.jsx
+++ b/src/sidebar/jsx/Topic.jsx
@@ -31,27 +31,69 @@ class Topic extends React.Component {
 		browser.contextMenus.onClicked.removeListener(this._contextMenuListener);
 	}
 
-	render() {
-		let fragments = this.props.details.map(hl => {
-			let deleteFrag=() => {
-				return this.props.deleteFrag(this.props.id,hl.id);
-			}
-			return <Fragment text={hl.text} id={hl.id} deleteFrag={deleteFrag}/>
-		});
-		let col = this.props.color;
-		let style = {
-			background: `rgb(${col.r}, ${col.g}, ${col.b})`
-		};
-		let name = this.props.name || ("unknown "+(this.props.index+1));
-		let count = this.props.details.length;
-		let onClick = this._handleClick;
-		return (<div>
-			<h3 style={style} className="topic" onClick={onClick}>
-				{name} <small class="counter">{count}</small>
-			</h3>
-			{this.state.open && <div class="fragments">{fragments}</div>}
-		</div>);
-	}
+  render() {
+    let fragments = this.props.details.map(hl => {
+      let deleteFrag=() => {
+        return this.props.deleteFrag(this.props.id,hl.id);
+      }
+      return <Fragment text={hl.text} id={hl.id} deleteFrag={deleteFrag}/>
+    });
+    let col = this.props.color;
+    let style = {
+      background: `rgb(${col.r}, ${col.g}, ${col.b})`
+    };
+    let name = this.props.name || ("unknown "+(this.props.index+1));
+    let count = this.props.details.length;
+    let onClick = this._handleClick;
+
+    let nameControl;
+
+    let setEdit = (e) => {
+      e.stopPropagation();
+      this.setState({edit:true});
+    }
+
+    if (this.state.edit) {
+
+      let endEdit = () => {
+        this.setState({edit:false});
+      }
+
+      let changeName = (newName) => {
+        if (newName!=this.props.name) {
+          this.props.renameTopic(this.props.id,newName).finally(endEdit);
+        } else {
+          endEdit();
+        }
+      }
+
+      let onKeyPress = (e) => {
+        if (e.key === 'Enter') {
+          changeName(e.target.value);
+        }
+      }
+      let onKeyUp = (e) => {
+        if (e.key === 'Escape') {
+          endEdit();
+        }
+      }
+
+      let onBlur = (e) => {
+        e.stopPropagation();
+        return changeName(e.target.value);
+      }
+      let dontClose = (e) => e.stopPropagation();
+      nameControl=<input onBlur={onBlur} onKeyPress={onKeyPress} onKeyUp={onKeyUp} onClick={dontClose} defaultValue={name}/>;
+    } else {
+      nameControl=<span onClick={setEdit}>{name}</span>;
+    }
+    return (<div>
+      <h3 style={style} className="topic" onClick={onClick}>
+        {nameControl} <small class="counter">{count}</small>
+      </h3>
+      {this.state.open && <div class="fragments">{fragments}</div>}
+    </div>);
+  }
 
 	_handleClick() {
 		this.setState({open: !this.state.open});

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -101,32 +101,29 @@ class Sidebar extends React.Component {
 		}
 	}
 
-	async _deleteFrag(viewpoint,topic,fragId) {
-		let uri=this.state.uri;
-		let res=browser.runtime.sendMessage({
-			aim:'removeHighlight',uri,viewpoint,topic,fragId
-		});
-		return res;
-	}
+  _deleteFrag(viewpoint,topic,fragId) {
+    let uri=this.state.uri;
+    return browser.runtime.sendMessage({
+      aim:'removeHighlight',uri,viewpoint,topic,fragId
+    });
+  }
 
-	async _createFrag(tab,viewpoint,topic) {
-		let uri=this.state.uri;
-		let coordinates = await browser.tabs.sendMessage(tab.id,{aim:"getCoordinates"});
-		if (!coordinates) {
-			console.error("error getting coordinates");
-			alert("error getting coordinates");
-			return;
-		}
-
-		let res=browser.runtime.sendMessage({
-			aim:'createHighlight',uri,viewpoint,topic,coordinates
-		}).then(x => {
-			browser.tabs.sendMessage(tab.id,{aim:"cleanSelection"});
-			return x;
-		});
-		return res;
-	}
-
+  _createFrag(tab,viewpoint,topic) {
+    let uri=this.state.uri;
+    return browser.tabs.sendMessage(tab.id,{aim:"getCoordinates"})
+      .then(coordinates => {
+        if (!coordinates) {
+          throw new Error("error getting coordinates");
+        }
+        return browser.runtime.sendMessage({
+          aim:'createHighlight',uri,viewpoint,topic,coordinates
+        });
+      })
+      .then(x => {
+        browser.tabs.sendMessage(tab.id,{aim:"cleanSelection"});
+        return x;
+      });
+  }
 
 }
 


### PR DESCRIPTION
Get the error given by the db library and transform it in information for the user.
Did that on the 2 current modification requests : #47 and #52

Currently using the notification system of Firefox, not sure if it is the most obvious to see for a user, could be changed.

But most of the modifications are in the function flow, as getting the error needs to be coherent in the way functions are called (synchronous vs asynchronous). This pull request proposes to use mainly synchronous method, and Promises, and avoid `async` and `await` keywords. If OK, we could generalize to all legacy code.